### PR TITLE
ContributeFix AttributeError in C1_W3_Lab01

### DIFF
--- a/C1 - Supervised Machine Learning - Regression and Classification/week3/Optional Labs/plt_one_addpt_onclick.py
+++ b/C1 - Supervised Machine Learning - Regression and Classification/week3/Optional Labs/plt_one_addpt_onclick.py
@@ -176,11 +176,26 @@ class plt_one_addpt_onclick:
         #print(f"bb     : {bcid.rectangles[0].get_bbox()}")
         #print(f"points : {bcid.rectangles[0].get_bbox().get_points()}")  #[[xmin,ymin],[xmax,ymax]]
 
-        h = bcid.rectangles[0].get_height()
-        bcid.rectangles[0].set_height(3*h)
+        if hasattr(bcid,'rectangles'):
+            # matplotlib 
+            h = bcid.rectangles[0].get_height()
+            bcid.rectangles[0].set_height(3*h)
 
-        ymax = bcid.rectangles[0].get_bbox().y1
-        ymin = bcid.rectangles[0].get_bbox().y0
+            ymax = bcid.rectangles[0].get_bbox().y1
+            ymin = bcid.rectangles[0].get_bbox().y0
 
-        bcid.lines[0][0].set_ydata([ymax,ymin])
-        bcid.lines[0][1].set_ydata([ymin,ymax])
+            bcid.lines[0][0].set_ydata([ymax,ymin])
+            bcid.lines[0][1].set_ydata([ymin,ymax])
+
+        elif hasattr(bcid,'boxes'):
+            # mpl_toolkits
+            h = bcid.boxes[0].get_height()
+            bcid.boxes[0].set_height(3*h)
+
+            ymax = bcid.boxes[0].get_bbox().y1
+            ymin = bcid.boxes[0].get_bbox().y0
+
+            bcid.lines[0][0].set_ydata([ymax,ymin])
+            bcid.lines[0][1].set_ydata([ymin,ymax])
+
+

--- a/C1 - Supervised Machine Learning - Regression and Classification/week3/Optional Labs/plt_one_addpt_onclick.py
+++ b/C1 - Supervised Machine Learning - Regression and Classification/week3/Optional Labs/plt_one_addpt_onclick.py
@@ -177,7 +177,7 @@ class plt_one_addpt_onclick:
         #print(f"points : {bcid.rectangles[0].get_bbox().get_points()}")  #[[xmin,ymin],[xmax,ymax]]
 
         if hasattr(bcid,'rectangles'):
-            # matplotlib 
+            # Buttons has attribute rectangles
             h = bcid.rectangles[0].get_height()
             bcid.rectangles[0].set_height(3*h)
 
@@ -188,7 +188,7 @@ class plt_one_addpt_onclick:
             bcid.lines[0][1].set_ydata([ymin,ymax])
 
         elif hasattr(bcid,'boxes'):
-            # mpl_toolkits
+            # Button has attribute boxes
             h = bcid.boxes[0].get_height()
             bcid.boxes[0].set_height(3*h)
 


### PR DESCRIPTION
# Problem

Due to a recent matplotlib update, the ```CheckButtons``` object no longer includes the ```rectangles``` attribute, causing:
```
AttributeError: 'CheckButtons' object has no attribute 'rectangles'
```

# Fix
- Kept the original support for rectangles;
- Added compatibility for the new boxes attribute;
- Used conditional checks to handle both cases dynamically;

Fix issues: #61 